### PR TITLE
Add additional test coverage, add usage to README

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [KyleMcMaster]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,100 @@ A small set of extensions to make test assertions more fluent when using CSharpF
 ## Dependencies
 
 This library is compatible with .NET 6+.
+
+## Usage
+
+### Maybe Assertions
+
+```csharp
+var maybe = Maybe.From("foo");
+
+maybe.Should().HaveValue("foo"); // passes
+maybe.Should().HaveValue("bar"); // throws
+maybe.Should().HaveNoValue(); // throws
+```
+
+```csharp
+Maybe<string> maybe = null;
+
+maybe.Should().HaveNoValue(); // passes
+maybe.Should().HaveValue("foo"); // throws
+```
+
+### Result Assertions 
+
+```csharp
+var result = Result.Success();
+
+result.Should().Succeed(); // passes
+result.Should().Fail() // throws
+```
+
+```csharp
+var result = Result.Failure("error");
+
+result.Should().Fail() // passes
+result.Should().FailWith("error"); // passes
+result.Should().FailWith("some other error"); // throws
+result.Should().Succeed(); // throws
+```
+
+### Generic Result of T Assertions
+
+```csharp
+var result = Result.Success(420);
+
+result.Should().Succeed(); // passes
+result.Should().SucceedWith(420); // passes
+result.Should().SucceedWith(69); // throws
+result.Should().Fail(); // throws
+```
+
+```csharp
+var result = Result.Failure<string>("error");
+
+result.Should().Fail() // passes
+result.Should().FailWith("error"); // passes
+result.Should().FailWith("some other error"); // throws
+result.Should().Succeed(); // throws
+```
+
+### Generic Result of T:Value and E:Exception Assertions
+
+```csharp
+var result = Result.Success<int, Exception>(420);
+
+result.Should().Succeed(); // passes
+result.Should().SucceedWith(420); // passes
+result.Should().SucceedWith(69); // throws
+result.Should().Fail(); // throws
+result.Should().FailWith(new Exception("error")); // throws
+```
+
+```csharp
+var result = Result.Failure<int, Exception>(new Exception("error"));
+
+result.Should().Fail(); // passes
+result.Should().FailWith(new Exception("error")); // passes
+result.Should().FailWith(new Exception("some other error")); // throws
+result.Should().Succeed(); // throws
+result.Should().SucceedWith(4680); // throws
+```
+
+### UnitResult Assertions
+
+```csharp
+var result = UnitResult.Success<string>();
+
+result.Should().Succeed(); // passes
+result.Should().Fail(); // throws
+result.Should().FailWith("error"); // throws
+```
+
+```csharp
+var result = UnitResult.Failure("error");
+
+result.Should().Fail(); // passes
+result.Should().FailWith("error"); // passes
+result.Should().Succeed(); // throws
+```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ result.Should().FailWith("some other error"); // throws
 result.Should().Succeed(); // throws
 ```
 
-### Generic Result of T:Value and E:Exception Assertions
+### Generic Result of T:Value and E:Error Assertions
 
 ```csharp
 var result = Result.Success<int, Exception>(420);

--- a/src/CSharpFunctionalExtensions.FluentAssertions/MaybeExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/MaybeExtensions.cs
@@ -33,7 +33,7 @@ public class MaybeAssertions<T> : ReferenceTypeAssertions<Maybe<T>, MaybeAsserti
                 _ => value)
             .Then
             .Given(s => s.Value)
-            .ForCondition(v => v.Equals(value))
+            .ForCondition(v => v!.Equals(value))
             .FailWith(
                 "Expected {context:maybe} to have value {0}{reason}, but with value {1} it",
                 _ => value,

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTEExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTEExtensions.cs
@@ -47,7 +47,7 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
             .FailWith("Expected Result to be successful but it failed")
             .Then
             .Given(s => s.Value)
-            .ForCondition(v => v.Equals(value))
+            .ForCondition(v => v!.Equals(value))
             .FailWith("Excepted Result value to be {0} but found {1}", value, Subject.Value);
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);
@@ -86,7 +86,7 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
             .FailWith("Expected Result to be failure but it succeeded")
             .Then
             .Given(s => s.Error)
-            .ForCondition(e => e.Equals(error))
+            .ForCondition(e => e!.Equals(error))
             .FailWith("Excepted Result value to be {0} but found {1}", error, Subject.Error);
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
@@ -48,7 +48,7 @@ public class ResultTAssertions<T> : ReferenceTypeAssertions<Result<T>, ResultTAs
             .FailWith("Expected Result to be successful but it failed")
             .Then
             .Given(s => s.Value)
-            .ForCondition(v => v.Equals(value))
+            .ForCondition(v => v!.Equals(value))
             .FailWith("Excepted Result value to be {0} but found {1}", value, Subject.Value);
 
         return new AndConstraint<ResultTAssertions<T>>(this);

--- a/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
@@ -64,7 +64,7 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
             .FailWith("Expected UnitResult to be failure but it succeeded")
             .Then
             .Given(s => s.Error)
-            .ForCondition(e => e.Equals(error))
+            .ForCondition(e => e!.Equals(error))
             .FailWith("Excepted UnitResult value to be {0} but found {1}", error, Subject.Error);
 
         return new AndConstraint<UnitResultAssertions<E>>(this);

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/MaybeAssertionsTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/MaybeAssertionsTests.cs
@@ -9,17 +9,17 @@ public class MaybeAssertionsTests
     [Fact]
     public void WhenMaybeIsExpectedToHaveValueAndItDoesShouldNotThrow()
     {
-        var x = Maybe.From("test");
+        var maybe = Maybe.From("test");
 
-        x.Should().HaveValue("test");
+        maybe.Should().HaveValue("test");
     }
 
     [Fact]
     public void WhenMaybeIsExpectedToHaveValueAndItHasWrongValueShouldThrow()
     {
-        var x = Maybe.From("oops");
+        var maybe = Maybe.From("oops");
 
-        Action act = () => x.Should().HaveValue("test", "it is test");
+        Action act = () => maybe.Should().HaveValue("test", "it is test");
 
         act.Should().Throw<Exception>().WithMessage($"*value \"test\" because it is test, but with value \"oops\" it*");
     }
@@ -27,9 +27,9 @@ public class MaybeAssertionsTests
     [Fact]
     public void WhenMaybeIsExpectedToHaveValueAndItDoesNotShouldThrow()
     {
-        Maybe<string> x = null;
+        Maybe<string> maybe = null;
 
-        Action act = () => x.Should().HaveValue("test", "it is not None");
+        Action act = () => maybe.Should().HaveValue("test", "it is not None");
 
         act.Should().Throw<Exception>().WithMessage($"*value \"test\" because it is not None*");
     }
@@ -37,17 +37,17 @@ public class MaybeAssertionsTests
     [Fact]
     public void WhenMaybeIsExpectedToHaveNoValueAndItHasNoneShouldNotThrow()
     {
-        Maybe<string> x = null;
+        Maybe<string> maybe = null;
 
-        x.Should().HaveNoValue();
+        maybe.Should().HaveNoValue();
     }
 
     [Fact]
     public void WhenMaybeIsExpectedToHaveNoValueAndItHasOneShouldThrow()
     {
-        var x = Maybe.From("test");
+        var maybe = Maybe.From("test");
 
-        Action act = () => x.Should().HaveNoValue("it is None");
+        Action act = () => maybe.Should().HaveNoValue("it is None");
 
         act.Should().Throw<Exception>().WithMessage($"*Maybe to have no value because it is None, but with value \"test\" it*");
     }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultAssertionTests.cs
@@ -9,17 +9,17 @@ public class ResultAssertionTests
     [Fact]
     public void WhenResultIsExpectedToHaveValueItShouldBeSuccessful()
     {
-        var x = Result.Success();
+        var result = Result.Success();
 
-        x.Should().Succeed();
+        result.Should().Succeed();
     }
 
     [Fact]
     public void WhenResultIsExpectedToHaveValueItShouldNotBeFailure()
     {
-        var x = Result.Success();
+        var result = Result.Success();
 
-        var action = () => x.Should().Fail();
+        var action = () => result.Should().Fail();
 
         action.Should().Throw<XunitException>().WithMessage("Expected Result to be failure but it succeeded");
     }
@@ -27,17 +27,17 @@ public class ResultAssertionTests
     [Fact]
     public void WhenResultIsExpectedToHaveErrorItShouldNotBeFailure()
     {
-        var x = Result.Failure("error");
+        var result = Result.Failure("error");
 
-        x.Should().Fail();
+        result.Should().Fail();
     }
 
     [Fact]
     public void WhenResultIsExpectedToHaveErrorItShouldBeFailure()
     {
-        var x = Result.Failure("error");
+        var result = Result.Failure("error");
 
-        var action = () => x.Should().Succeed();
+        var action = () => result.Should().Succeed();
 
         action.Should().Throw<XunitException>().WithMessage("Expected Result to be successful but it failed");
     }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTAssertionsTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTAssertionsTests.cs
@@ -9,17 +9,17 @@ public class ResultAssertionsTests
     [Fact]
     public void WhenResultIsExpectedToHaveValueItShouldBeSuccessful()
     {
-        var x = Result.Success("test");
+        var result = Result.Success("test");
 
-        x.Should().Succeed();
+        result.Should().Succeed();
     }
 
     [Fact]
     public void WhenResultIsExpectedToHaveValueItShouldNotBeFailure()
     {
-        var x = Result.Success("test");
+        var result = Result.Success("test");
 
-        var action = () => x.Should().Fail();
+        var action = () => result.Should().Fail();
 
         action.Should().Throw<XunitException>().WithMessage("Expected Result to be failure but it succeeded");
     }
@@ -28,17 +28,17 @@ public class ResultAssertionsTests
     public void WhenResultIsExpectedToHaveValueItShouldBeSuccessfulWithValue()
     {
         string expected = "test";
-        var x = Result.Success(expected);
+        var result = Result.Success(expected);
 
-        x.Should().SucceedWith(expected);
+        result.Should().SucceedWith(expected);
     }
 
     [Fact]
     public void WhenResultIsExpectedToHaveValueItShouldNotBeSuccessfulWithDifferentValue()
     {
-        var x = Result.Success("foo");
+        var result = Result.Success("foo");
 
-        var action = () => x.Should().SucceedWith("bar");
+        var action = () => result.Should().SucceedWith("bar");
 
         action.Should().Throw<XunitException>().WithMessage(@"Excepted Result value to be ""bar"" but found ""foo""");
     }
@@ -46,17 +46,17 @@ public class ResultAssertionsTests
     [Fact]
     public void WhenResultIsExpectedToHaveErrorItShouldNotBeFailure()
     {
-        var x = Result.Failure<string>("error");
+        var result = Result.Failure<string>("error");
 
-        x.Should().Fail();
+        result.Should().Fail();
     }
 
     [Fact]
     public void WhenResultIsExpectedToHaveErrorItShouldBeFailure()
     {
-        var x = Result.Failure<string>("error");
+        var result = Result.Failure<string>("error");
 
-        var action = () => x.Should().Succeed();
+        var action = () => result.Should().Succeed();
 
         action.Should().Throw<XunitException>().WithMessage("Expected Result to be successful but it failed");
     }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTEAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTEAssertionTests.cs
@@ -18,6 +18,15 @@ public class ResultTEAssertionTests
     }
 
     [Fact]
+    public void WhenResultIsExpectedToBeSuccessWithValueItShouldBeSuccessWithValue()
+    {
+        string value = "value";
+        var result = Result.Success<string, Exception>(value);
+
+        result.Should().SucceedWith(value);
+    }
+
+    [Fact]
     public void WhenResultIsExpectedToBeSuccessItShouldThrowWhenFailure()
     {
         var error = new Exception("error");
@@ -26,6 +35,17 @@ public class ResultTEAssertionTests
         var action = () => result.Should().Succeed();
 
         action.Should().Throw<XunitException>().WithMessage("Expected Result to be successful but it failed");
+    }
+
+    [Fact]
+    public void WhenResultIsExpectedToBeSuccessWithValueItShouldThrowWhenSuccessWithDifferentValue()
+    {
+        string value = "value";
+        var result = Result.Success<string, Exception>(value);
+
+        var action = () => result.Should().SucceedWith("some other value");
+
+        action.Should().Throw<XunitException>().WithMessage("Excepted Result value to be \"some other value\" but found \"value\"");
     }
 
     [Fact]
@@ -39,6 +59,26 @@ public class ResultTEAssertionTests
 
         action.Should().NotThrow();
         actionWith.Should().NotThrow();
+    }
+
+    [Fact]
+    public void WhenResultIsExpectedToBeFailureWithValueItShouldBeFailureWithValue()
+    {
+        var error = new Exception("error");
+        var result = Result.Failure<string, Exception>(error);
+
+        result.Should().FailWith(error);
+    }
+
+    [Fact]
+    public void WhenResultIsExpectedToBeFailureWithValueItShouldThrowWhenFailureWithDifferenceValue()
+    {
+        var error = new Exception("error");
+        var result = Result.Failure<string, Exception>(error);
+
+        var action = () => result.Should().FailWith(new Exception("Some other error"));
+
+        action.Should().Throw<XunitException>().WithMessage("Excepted Result value to be System.Exception with message \"Some other error\" but found System.Exception with message \"error\"");
     }
 
     [Fact]

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
@@ -38,6 +38,26 @@ public class UnitResultAssertionTests
     }
 
     [Fact]
+    public void WhenResultIsExpectedToBeFailureWithValueItShouldBeFailureWithValue()
+    {
+        string error = "error";
+        var r = UnitResult.Failure(error);
+
+        r.Should().FailWith(error);
+    }
+
+    [Fact]
+    public void WhenResultIsExpectedToBeFailureWithValueItShouldThrowWhenFailureWithDifferenceValue()
+    {
+        string error = "error";
+        var r = UnitResult.Failure(error);
+
+        var action = () => r.Should().FailWith("some other error");
+
+        action.Should().Throw<XunitException>().WithMessage("Excepted UnitResult value to be \"some other error\" but found \"error\"");
+    }
+
+    [Fact]
     public void WhenResultIsExpectedToBeFailureItShouldThrowWhenSuccess()
     {
         var r = UnitResult.Success<string>();

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
@@ -8,8 +8,9 @@ public class UnitResultAssertionTests
     [Fact]
     public void WhenResultIsExpectedToBeSuccessItShouldBeSuccess()
     {
-        var r = UnitResult.Success<string>();
-        var action = () => r.Should().Succeed();
+        var result = UnitResult.Success<string>();
+
+        var action = () => result.Should().Succeed();
 
         action.Should().NotThrow();
     }
@@ -18,8 +19,9 @@ public class UnitResultAssertionTests
     public void WhenResultIsExpectedToBeSuccessItShouldThrowWhenFailure()
     {
         string error = "error";
-        var r = UnitResult.Failure(error);
-        var action = () => r.Should().Succeed();
+        var result = UnitResult.Failure(error);
+
+        var action = () => result.Should().Succeed();
 
         action.Should().Throw<XunitException>().WithMessage("Expected UnitResult to be successful but it failed");
     }
@@ -28,10 +30,10 @@ public class UnitResultAssertionTests
     public void WhenResultIsExpectedToBeFailureItShouldBeFailure()
     {
         string error = "error";
-        var r = UnitResult.Failure(error);
+        var result = UnitResult.Failure(error);
 
-        var action = () => r.Should().Fail();
-        var actionWithError = () => r.Should().FailWith(error);
+        var action = () => result.Should().Fail();
+        var actionWithError = () => result.Should().FailWith(error);
 
         action.Should().NotThrow();
         actionWithError.Should().NotThrow();
@@ -41,18 +43,18 @@ public class UnitResultAssertionTests
     public void WhenResultIsExpectedToBeFailureWithValueItShouldBeFailureWithValue()
     {
         string error = "error";
-        var r = UnitResult.Failure(error);
+        var result = UnitResult.Failure(error);
 
-        r.Should().FailWith(error);
+        result.Should().FailWith(error);
     }
 
     [Fact]
     public void WhenResultIsExpectedToBeFailureWithValueItShouldThrowWhenFailureWithDifferenceValue()
     {
         string error = "error";
-        var r = UnitResult.Failure(error);
+        var result = UnitResult.Failure(error);
 
-        var action = () => r.Should().FailWith("some other error");
+        var action = () => result.Should().FailWith("some other error");
 
         action.Should().Throw<XunitException>().WithMessage("Excepted UnitResult value to be \"some other error\" but found \"error\"");
     }
@@ -60,9 +62,9 @@ public class UnitResultAssertionTests
     [Fact]
     public void WhenResultIsExpectedToBeFailureItShouldThrowWhenSuccess()
     {
-        var r = UnitResult.Success<string>();
+        var result = UnitResult.Success<string>();
 
-        var action = () => r.Should().Fail();
+        var action = () => result.Should().Fail();
 
         action.Should().Throw<XunitException>().WithMessage("Expected UnitResult to be failure but it succeeded");
     }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
@@ -38,6 +38,15 @@ public class UnitResultAssertionTests
     }
 
     [Fact]
+    public void WhenResultIsExpectedToBeFailureWithValueItShouldBeFailureWithValue()
+    {
+        string error = "error";
+        var r = UnitResult.Failure(error);
+
+        r.Should().FailWith(error);
+    }
+
+    [Fact]
     public void WhenResultIsExpectedToBeFailureItShouldThrowWhenSuccess()
     {
         var r = UnitResult.Success<string>();


### PR DESCRIPTION
- fixes C# compiler warnings for possible null values
- adds additional test coverage for "With" extensions where values may be checked for equivalency
- update README with usage