### PR TITLE
feat(Maybe): Added HaveSomeValue()

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This library is compatible with .NET 6+.
 ```csharp
 var maybe = Maybe.From("foo");
 
+maybe.Should().HaveSomeValue(); // passes
 maybe.Should().HaveValue("foo"); // passes
 maybe.Should().HaveValue("bar"); // throws
 maybe.Should().HaveNoValue(); // throws

--- a/src/CSharpFunctionalExtensions.FluentAssertions/MaybeExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/MaybeExtensions.cs
@@ -14,6 +14,23 @@ public class MaybeAssertions<T> : ReferenceTypeAssertions<Maybe<T>, MaybeAsserti
     public MaybeAssertions(Maybe<T> instance) : base(instance) { }
 
     protected override string Identifier => "Maybe{T}";
+    
+    /// <summary>
+    /// Asserts that the current <see cref="Maybe{T}"/> has some value.
+    /// </summary>
+    /// <param name="because"></param>
+    /// <param name="becauseArgs"></param>
+    /// <returns></returns>
+    public AndConstraint<MaybeAssertions<T>> HaveSomeValue(string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .Given(() => Subject)
+            .ForCondition(v => v.HasValue)
+            .FailWith("Expected a value{reason}");
+
+        return new AndConstraint<MaybeAssertions<T>>(this);
+    }
 
     /// <summary>
     /// Asserts that the current <see cref="Maybe{T}"/> has a value.

--- a/src/CSharpFunctionalExtensions.FluentAssertions/MaybeExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/MaybeExtensions.cs
@@ -27,7 +27,7 @@ public class MaybeAssertions<T> : ReferenceTypeAssertions<Maybe<T>, MaybeAsserti
             .BecauseOf(because, becauseArgs)
             .Given(() => Subject)
             .ForCondition(v => v.HasValue)
-            .FailWith("Expected a value{reason}");
+            .FailWith("Expected a value {reason}");
 
         return new AndConstraint<MaybeAssertions<T>>(this);
     }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/MaybeAssertionsTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/MaybeAssertionsTests.cs
@@ -7,6 +7,14 @@ namespace CSharpFunctionalExtensions.FluentAssertions.Tests;
 public class MaybeAssertionsTests
 {
     [Fact]
+    public void WhenMaybeIsExpectedToHaveSomeValueAndItDoesShouldNotThrow()
+    {
+        var maybe = Maybe.From("test");
+
+        maybe.Should().HaveSomeValue();
+    }
+    
+    [Fact]
     public void WhenMaybeIsExpectedToHaveValueAndItDoesShouldNotThrow()
     {
         var maybe = Maybe.From("test");


### PR DESCRIPTION
I've added the extension `HaveSomeValue()` that simply asserts that maybe holds some value, without requiring to test the value.
