### PR TITLE
Result values in failure messages

### DIFF
--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultExtensions.cs
@@ -26,7 +26,7 @@ public class ResultAssertions : ReferenceTypeAssertions<Result, ResultAssertions
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsSuccess)
-            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""));
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to succeed{{reason}}, but it failed with error ""{Subject.Error}"""));
 
         return new AndConstraint<ResultAssertions>(this);
     }
@@ -42,7 +42,7 @@ public class ResultAssertions : ReferenceTypeAssertions<Result, ResultAssertions
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsFailure)
-            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure{{reason}} but it succeeded"));
+            .FailWith(() => new FailReason($"Expected {{context:result}} to fail{{reason}}, but it succeeded"));
 
         return new AndConstraint<ResultAssertions>(this);
     }

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultExtensions.cs
@@ -25,9 +25,8 @@ public class ResultAssertions : ReferenceTypeAssertions<Result, ResultAssertions
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsSuccess)
-            .FailWith("Expected Result to be successful but it failed");
+            .ForCondition(Subject.IsSuccess)
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""));
 
         return new AndConstraint<ResultAssertions>(this);
     }
@@ -42,9 +41,8 @@ public class ResultAssertions : ReferenceTypeAssertions<Result, ResultAssertions
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsFailure)
-            .FailWith("Expected Result to be failure but it succeeded");
+            .ForCondition(Subject.IsFailure)
+            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure{{reason}} but it succeeded"));
 
         return new AndConstraint<ResultAssertions>(this);
     }

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTEExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTEExtensions.cs
@@ -25,7 +25,7 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsSuccess)
-            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""));
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to succeed{{reason}}, but it failed with error ""{Subject.Error}"""));
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);
     }
@@ -42,11 +42,11 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsSuccess)
-            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""))
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to succeed{{reason}}, but it failed with error ""{Subject.Error}"""))
             .Then
             .Given(() => Subject.Value)
             .ForCondition(v => v!.Equals(value))
-            .FailWith("Expected Result value to be {0} but found {1}", value, Subject.Value);
+            .FailWith("Expected {context:result} value to be {0}, but found {1}", value, Subject.Value);
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);
     }
@@ -62,7 +62,7 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsFailure)
-            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"));
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to fail, but it succeeded with value ""{Subject.Value}"""));
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);
     }
@@ -79,11 +79,11 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsFailure)
-            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"))
+            .FailWith(() => new FailReason($"Expected {{context:result}} to fail, but it succeeded"))
             .Then
             .Given(() => Subject.Error)
             .ForCondition(e => e!.Equals(error))
-            .FailWith("Expected Result value to be {0} but found {1}", error, Subject.Error);
+            .FailWith($"Expected {{context:result}} error to be {{0}}, but found {{1}}", error, Subject.Error);
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);
     }

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTEExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTEExtensions.cs
@@ -24,9 +24,8 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsSuccess)
-            .FailWith("Expected Result to be successful but it failed");
+            .ForCondition(Subject.IsSuccess)
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""));
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);
     }
@@ -42,13 +41,12 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsSuccess)
-            .FailWith("Expected Result to be successful but it failed")
+            .ForCondition(Subject.IsSuccess)
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""))
             .Then
-            .Given(s => s.Value)
+            .Given(() => Subject.Value)
             .ForCondition(v => v!.Equals(value))
-            .FailWith("Excepted Result value to be {0} but found {1}", value, Subject.Value);
+            .FailWith("Expected Result value to be {0} but found {1}", value, Subject.Value);
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);
     }
@@ -63,9 +61,8 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsFailure)
-            .FailWith("Expected Result to be failure but it succeeded");
+            .ForCondition(Subject.IsFailure)
+            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"));
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);
     }
@@ -81,13 +78,12 @@ public class ResultTEAssertions<T, E> : ReferenceTypeAssertions<Result<T, E>, Re
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsFailure)
-            .FailWith("Expected Result to be failure but it succeeded")
+            .ForCondition(Subject.IsFailure)
+            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"))
             .Then
-            .Given(s => s.Error)
+            .Given(() => Subject.Error)
             .ForCondition(e => e!.Equals(error))
-            .FailWith("Excepted Result value to be {0} but found {1}", error, Subject.Error);
+            .FailWith("Expected Result value to be {0} but found {1}", error, Subject.Error);
 
         return new AndConstraint<ResultTEAssertions<T, E>>(this);
     }

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
@@ -26,7 +26,7 @@ public class ResultTAssertions<T> : ReferenceTypeAssertions<Result<T>, ResultTAs
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsSuccess)
-            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""));
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to succeed{{reason}}, but it failed with error ""{Subject.Error}"""));
 
         return new AndConstraint<ResultTAssertions<T>>(this);
     }
@@ -43,11 +43,11 @@ public class ResultTAssertions<T> : ReferenceTypeAssertions<Result<T>, ResultTAs
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsSuccess)
-            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""))
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to succeed{{reason}}, but it failed with error ""{Subject.Error}"""))
             .Then
             .Given(() => Subject.Value)
             .ForCondition(v => v!.Equals(value))
-            .FailWith("Expected Result value to be {0} but found {1}", value, Subject.Value);
+            .FailWith($"Expected {{context:result}} value to be {{0}}, but found {{1}}", value, Subject.Value);
 
         return new AndConstraint<ResultTAssertions<T>>(this);
     }
@@ -63,7 +63,7 @@ public class ResultTAssertions<T> : ReferenceTypeAssertions<Result<T>, ResultTAs
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsFailure)
-            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"));
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to fail, but it succeeded with value ""{Subject.Value}"""));
 
         return new AndConstraint<ResultTAssertions<T>>(this);
     }

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
@@ -25,9 +25,8 @@ public class ResultTAssertions<T> : ReferenceTypeAssertions<Result<T>, ResultTAs
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsSuccess)
-            .FailWith("Expected Result to be successful but it failed");
+            .ForCondition(Subject.IsSuccess)
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""));
 
         return new AndConstraint<ResultTAssertions<T>>(this);
     }
@@ -43,13 +42,12 @@ public class ResultTAssertions<T> : ReferenceTypeAssertions<Result<T>, ResultTAs
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsSuccess)
-            .FailWith("Expected Result to be successful but it failed")
+            .ForCondition(Subject.IsSuccess)
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""))
             .Then
-            .Given(s => s.Value)
+            .Given(() => Subject.Value)
             .ForCondition(v => v!.Equals(value))
-            .FailWith("Excepted Result value to be {0} but found {1}", value, Subject.Value);
+            .FailWith("Expected Result value to be {0} but found {1}", value, Subject.Value);
 
         return new AndConstraint<ResultTAssertions<T>>(this);
     }
@@ -64,9 +62,8 @@ public class ResultTAssertions<T> : ReferenceTypeAssertions<Result<T>, ResultTAs
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsFailure)
-            .FailWith("Expected Result to be failure but it succeeded");
+            .ForCondition(Subject.IsFailure)
+            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"));
 
         return new AndConstraint<ResultTAssertions<T>>(this);
     }

--- a/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
@@ -24,9 +24,8 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsSuccess)
-            .FailWith("Expected UnitResult to be successful but it failed");
+            .ForCondition(Subject.IsSuccess)
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""));
 
         return new AndConstraint<UnitResultAssertions<E>>(this);
     }
@@ -41,9 +40,8 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsFailure)
-            .FailWith("Expected UnitResult to be failure but it succeeded");
+            .ForCondition(Subject.IsFailure)
+            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"));
 
         return new AndConstraint<UnitResultAssertions<E>>(this);
     }
@@ -59,11 +57,10 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
     {
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
-            .Given(() => Subject)
-            .ForCondition(s => s.IsFailure)
-            .FailWith("Expected UnitResult to be failure but it succeeded")
+            .ForCondition(Subject.IsFailure)
+            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"))
             .Then
-            .Given(s => s.Error)
+            .Given(() => Subject.Error)
             .ForCondition(e => e!.Equals(error))
             .FailWith("Excepted UnitResult value to be {0} but found {1}", error, Subject.Error);
 

--- a/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
@@ -25,7 +25,7 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsSuccess)
-            .FailWith(() => new FailReason(@$"Expected {{context:result}} to be successful{{reason}} but it failed with error ""{Subject.Error}"""));
+            .FailWith(() => new FailReason(@$"Expected {{context:result}} to succeed{{reason}}, but it failed with error ""{Subject.Error}"""));
 
         return new AndConstraint<UnitResultAssertions<E>>(this);
     }
@@ -41,13 +41,13 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsFailure)
-            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"));
+            .FailWith(() => new FailReason($"Expected {{context:result}} to fail, but it succeeded"));
 
         return new AndConstraint<UnitResultAssertions<E>>(this);
     }
 
     /// <summary>
-    /// Asserts a unit result is a failure with a specfied error.
+    /// Asserts a unit result is a failure with a specified error.
     /// </summary>
     /// <param name="error"></param>
     /// <param name="because"></param>
@@ -58,11 +58,11 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
         Execute.Assertion
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.IsFailure)
-            .FailWith(() => new FailReason($"Expected {{context:result}} to be failure but it succeeded"))
+            .FailWith(() => new FailReason($"Expected {{context:result}} to fail, but it succeeded"))
             .Then
             .Given(() => Subject.Error)
             .ForCondition(e => e!.Equals(error))
-            .FailWith("Excepted UnitResult value to be {0} but found {1}", error, Subject.Error);
+            .FailWith($"Expected {{context:result}} error to be {{0}}, but found {{1}}", error, Subject.Error);
 
         return new AndConstraint<UnitResultAssertions<E>>(this);
     }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultAssertionTests.cs
@@ -21,7 +21,7 @@ public class ResultAssertionTests
 
         var action = () => result.Should().Fail();
 
-        action.Should().Throw<XunitException>().WithMessage("Expected Result to be failure but it succeeded");
+        action.Should().Throw<XunitException>().WithMessage("Expected result to be failure but it succeeded");
     }
 
     [Fact]
@@ -39,6 +39,6 @@ public class ResultAssertionTests
 
         var action = () => result.Should().Succeed();
 
-        action.Should().Throw<XunitException>().WithMessage("Expected Result to be successful but it failed");
+        action.Should().Throw<XunitException>().WithMessage(@"Expected result to be successful but it failed with error ""error""");
     }
 }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultAssertionTests.cs
@@ -21,7 +21,7 @@ public class ResultAssertionTests
 
         var action = () => result.Should().Fail();
 
-        action.Should().Throw<XunitException>().WithMessage("Expected result to be failure but it succeeded");
+        action.Should().Throw<XunitException>().WithMessage($"Expected {nameof(result)} to fail, but it succeeded");
     }
 
     [Fact]
@@ -39,6 +39,6 @@ public class ResultAssertionTests
 
         var action = () => result.Should().Succeed();
 
-        action.Should().Throw<XunitException>().WithMessage(@"Expected result to be successful but it failed with error ""error""");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} to succeed, but it failed with error ""error""");
     }
 }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTAssertionsTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTAssertionsTests.cs
@@ -21,7 +21,7 @@ public class ResultAssertionsTests
 
         var action = () => result.Should().Fail();
 
-        action.Should().Throw<XunitException>().WithMessage("Expected result to be failure but it succeeded");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} to fail, but it succeeded with value ""test""");
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class ResultAssertionsTests
 
         var action = () => result.Should().SucceedWith("bar");
 
-        action.Should().Throw<XunitException>().WithMessage(@"Expected Result value to be ""bar"" but found ""foo""");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} value to be ""bar"", but found ""foo""");
     }
 
     [Fact]
@@ -58,6 +58,6 @@ public class ResultAssertionsTests
 
         var action = () => result.Should().Succeed();
 
-        action.Should().Throw<XunitException>().WithMessage(@"Expected result to be successful but it failed with error ""error""");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} to succeed, but it failed with error ""error""");
     }
 }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTAssertionsTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTAssertionsTests.cs
@@ -21,7 +21,7 @@ public class ResultAssertionsTests
 
         var action = () => result.Should().Fail();
 
-        action.Should().Throw<XunitException>().WithMessage("Expected Result to be failure but it succeeded");
+        action.Should().Throw<XunitException>().WithMessage("Expected result to be failure but it succeeded");
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class ResultAssertionsTests
 
         var action = () => result.Should().SucceedWith("bar");
 
-        action.Should().Throw<XunitException>().WithMessage(@"Excepted Result value to be ""bar"" but found ""foo""");
+        action.Should().Throw<XunitException>().WithMessage(@"Expected Result value to be ""bar"" but found ""foo""");
     }
 
     [Fact]
@@ -58,6 +58,6 @@ public class ResultAssertionsTests
 
         var action = () => result.Should().Succeed();
 
-        action.Should().Throw<XunitException>().WithMessage("Expected Result to be successful but it failed");
+        action.Should().Throw<XunitException>().WithMessage(@"Expected result to be successful but it failed with error ""error""");
     }
 }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTEAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTEAssertionTests.cs
@@ -34,7 +34,7 @@ public class ResultTEAssertionTests
 
         var action = () => result.Should().Succeed();
 
-        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} to be successful but it failed with error ""System.Exception: error""");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} to succeed, but it failed with error ""System.Exception: error""");
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class ResultTEAssertionTests
 
         var action = () => result.Should().SucceedWith("some other value");
 
-        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} value to be ""some other value"" but found ""value""");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} value to be ""some other value"", but found ""value""");
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class ResultTEAssertionTests
 
         var action = () => result.Should().FailWith(new Exception("Some other error"));
 
-        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} value to be System.Exception with message ""Some other error"" but found System.Exception with message ""error""");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} error to be System.Exception with message ""Some other error"", but found System.Exception with message ""error""");
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public class ResultTEAssertionTests
         var action = () => result.Should().Fail();
         var actionWith = () => result.Should().FailWith(someError);
 
-        action.Should().Throw<XunitException>().WithMessage("Expected result to be failure but it succeeded");
-        actionWith.Should().Throw<XunitException>().WithMessage("Expected result to be failure but it succeeded");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} to fail, but it succeeded with value ""{value}""");
+        actionWith.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} to fail, but it succeeded");
     }
 }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTEAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTEAssertionTests.cs
@@ -34,7 +34,7 @@ public class ResultTEAssertionTests
 
         var action = () => result.Should().Succeed();
 
-        action.Should().Throw<XunitException>().WithMessage("Expected Result to be successful but it failed");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} to be successful but it failed with error ""System.Exception: error""");
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class ResultTEAssertionTests
 
         var action = () => result.Should().SucceedWith("some other value");
 
-        action.Should().Throw<XunitException>().WithMessage("Excepted Result value to be \"some other value\" but found \"value\"");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} value to be ""some other value"" but found ""value""");
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class ResultTEAssertionTests
 
         var action = () => result.Should().FailWith(new Exception("Some other error"));
 
-        action.Should().Throw<XunitException>().WithMessage("Excepted Result value to be System.Exception with message \"Some other error\" but found System.Exception with message \"error\"");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} value to be System.Exception with message ""Some other error"" but found System.Exception with message ""error""");
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public class ResultTEAssertionTests
         var action = () => result.Should().Fail();
         var actionWith = () => result.Should().FailWith(someError);
 
-        action.Should().Throw<XunitException>().WithMessage("Expected Result to be failure but it succeeded");
-        actionWith.Should().Throw<XunitException>().WithMessage("Expected Result to be failure but it succeeded");
+        action.Should().Throw<XunitException>().WithMessage("Expected result to be failure but it succeeded");
+        actionWith.Should().Throw<XunitException>().WithMessage("Expected result to be failure but it succeeded");
     }
 }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
@@ -23,7 +23,7 @@ public class UnitResultAssertionTests
 
         var action = () => result.Should().Succeed();
 
-        action.Should().Throw<XunitException>().WithMessage(@"Expected result to be successful but it failed with error ""error""");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} to succeed, but it failed with error ""{error}""");
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class UnitResultAssertionTests
 
         var action = () => result.Should().FailWith("some other error");
 
-        action.Should().Throw<XunitException>().WithMessage(@$"Excepted UnitResult value to be ""some other error"" but found ""error""");
+        action.Should().Throw<XunitException>().WithMessage(@$"Expected {nameof(result)} error to be ""some other error"", but found ""{error}""");
     }
 
     [Fact]
@@ -66,6 +66,6 @@ public class UnitResultAssertionTests
 
         var action = () => result.Should().Fail();
 
-        action.Should().Throw<XunitException>().WithMessage($"Expected {nameof(result)} to be failure but it succeeded");
+        action.Should().Throw<XunitException>().WithMessage($"Expected {nameof(result)} to fail, but it succeeded");
     }
 }

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/UnitResultAssertionTests.cs
@@ -23,7 +23,7 @@ public class UnitResultAssertionTests
 
         var action = () => result.Should().Succeed();
 
-        action.Should().Throw<XunitException>().WithMessage("Expected UnitResult to be successful but it failed");
+        action.Should().Throw<XunitException>().WithMessage(@"Expected result to be successful but it failed with error ""error""");
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class UnitResultAssertionTests
 
         var action = () => result.Should().FailWith("some other error");
 
-        action.Should().Throw<XunitException>().WithMessage("Excepted UnitResult value to be \"some other error\" but found \"error\"");
+        action.Should().Throw<XunitException>().WithMessage(@$"Excepted UnitResult value to be ""some other error"" but found ""error""");
     }
 
     [Fact]
@@ -66,6 +66,6 @@ public class UnitResultAssertionTests
 
         var action = () => result.Should().Fail();
 
-        action.Should().Throw<XunitException>().WithMessage("Expected UnitResult to be failure but it succeeded");
+        action.Should().Throw<XunitException>().WithMessage($"Expected {nameof(result)} to be failure but it succeeded");
     }
 }


### PR DESCRIPTION
When asserting for success and the Result actually fails, the error is not specified in test output, only "Expected Result to be successful but it failed". This complicates the testing process, as for each failing test the user has to analyze the output or re-run the test under the debugger to determine the cause of failure.

In this PR, error and success values are included in test output if an assertion fails. Also the messages themselves are slightly improved to make them more readable.

For example:
`Expected Result to be successful but it failed` -> `Expected myAwesomeResult to succeed, but it failed with error "some error"`
`Expected Result to be failure but it succeeded` -> `Expected myAwesomeResult to fail, but it succeeded with value "foo"`