### PR TITLE
Change Namespace To Match FluentAssertions

### DIFF
--- a/src/CSharpFunctionalExtensions.FluentAssertions/MaybeExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/MaybeExtensions.cs
@@ -1,8 +1,8 @@
-﻿using FluentAssertions;
+﻿using CSharpFunctionalExtensions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 
-namespace CSharpFunctionalExtensions.FluentAssertions;
+namespace FluentAssertions;
 
 public static class MaybeExtensions
 {
@@ -14,7 +14,7 @@ public class MaybeAssertions<T> : ReferenceTypeAssertions<Maybe<T>, MaybeAsserti
     public MaybeAssertions(Maybe<T> instance) : base(instance) { }
 
     protected override string Identifier => "Maybe{T}";
-    
+
     /// <summary>
     /// Asserts that the current <see cref="Maybe{T}"/> has some value.
     /// </summary>

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultExtensions.cs
@@ -1,8 +1,8 @@
-﻿using FluentAssertions;
+﻿using CSharpFunctionalExtensions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 
-namespace CSharpFunctionalExtensions.FluentAssertions;
+namespace FluentAssertions;
 
 public static class ResultExtensions
 {

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTEExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTEExtensions.cs
@@ -1,8 +1,8 @@
-﻿using FluentAssertions.Execution;
+﻿using CSharpFunctionalExtensions;
+using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
-using FluentAssertions;
 
-namespace CSharpFunctionalExtensions.FluentAssertions;
+namespace FluentAssertions;
 public static class ResultTEExtensions
 {
     public static ResultTEAssertions<T, E> Should<T, E>(this Result<T, E> instance) => new(instance);

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
@@ -1,8 +1,8 @@
-﻿using FluentAssertions;
+﻿using CSharpFunctionalExtensions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 
-namespace CSharpFunctionalExtensions.FluentAssertions;
+namespace FluentAssertions;
 
 public static class ResultTExtensions
 {

--- a/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
@@ -1,8 +1,8 @@
-﻿using FluentAssertions.Execution;
+﻿using CSharpFunctionalExtensions;
+using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
-using FluentAssertions;
 
-namespace CSharpFunctionalExtensions.FluentAssertions;
+namespace FluentAssertions;
 public static class UnitResultExtensions
 {
     public static UnitResultAssertions<E> Should<E>(this UnitResult<E> instance) => new(instance);

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/MaybeAssertionsTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/MaybeAssertionsTests.cs
@@ -27,7 +27,7 @@ public class MaybeAssertionsTests
     {
         var maybe = Maybe.From("oops");
 
-        Action act = () => maybe.Should().HaveValue("test", "it is test");
+        var act = () => maybe.Should().HaveValue("test", "it is test");
 
         act.Should().Throw<Exception>().WithMessage($"*value \"test\" because it is test, but with value \"oops\" it*");
     }
@@ -37,7 +37,7 @@ public class MaybeAssertionsTests
     {
         Maybe<string> maybe = null;
 
-        Action act = () => maybe.Should().HaveValue("test", "it is not None");
+        var act = () => maybe.Should().HaveValue("test", "it is not None");
 
         act.Should().Throw<Exception>().WithMessage($"*value \"test\" because it is not None*");
     }
@@ -55,7 +55,7 @@ public class MaybeAssertionsTests
     {
         var maybe = Maybe.From("test");
 
-        Action act = () => maybe.Should().HaveNoValue("it is None");
+        var act = () => maybe.Should().HaveNoValue("it is None");
 
         act.Should().Throw<Exception>().WithMessage($"*Maybe to have no value because it is None, but with value \"test\" it*");
     }


### PR DESCRIPTION
- Changes namespace of Assertions to match FluentAssertions, making developer experience a little easier when managing usings in tests.