### PR TITLE
Add Missing FailWith Assertions

### DIFF
--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultExtensions.cs
@@ -46,4 +46,22 @@ public class ResultAssertions : ReferenceTypeAssertions<Result, ResultAssertions
 
         return new AndConstraint<ResultAssertions>(this);
     }
+
+    /// <summary>
+    /// Asserts a result is a failure with a specified error.
+    /// </summary>
+    /// <param name="error"></param>
+    /// <param name="because"></param>
+    /// <param name="becauseArgs"></param>
+    /// <returns></returns>
+    public AndConstraint<ResultAssertions> FailWith(string error, string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .Given(() => Subject.IsFailure)
+            .ForCondition(b => Subject.Error!.Equals(error))
+            .FailWith($"Expected {{context:result}} error to be {{0}}, but found {{1}}", error, Subject.Error);
+
+        return new AndConstraint<ResultAssertions>(this);
+    }
 }

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
@@ -67,4 +67,22 @@ public class ResultTAssertions<T> : ReferenceTypeAssertions<Result<T>, ResultTAs
 
         return new AndConstraint<ResultTAssertions<T>>(this);
     }
+
+    /// <summary>
+    /// Asserts a result is a failure with a specified error.
+    /// </summary>
+    /// <param name="error"></param>
+    /// <param name="because"></param>
+    /// <param name="becauseArgs"></param>
+    /// <returns></returns>
+    public AndConstraint<ResultTAssertions<T>> FailWith(string error, string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .Given(() => Subject.IsFailure)
+            .ForCondition(b => Subject.Error!.Equals(error))
+            .FailWith($"Expected {{context:result}} error to be {{0}}, but found {{1}}", error, Subject.Error);
+
+        return new AndConstraint<ResultTAssertions<T>>(this);
+    }
 }

--- a/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/ResultTExtensions.cs
@@ -53,7 +53,7 @@ public class ResultTAssertions<T> : ReferenceTypeAssertions<Result<T>, ResultTAs
     }
 
     /// <summary>
-    /// Asserts a result is a failure
+    /// Asserts a result is a failure.
     /// </summary>
     /// <param name="because"></param>
     /// <param name="becauseArgs"></param>

--- a/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/UnitResultExtensions.cs
@@ -15,7 +15,7 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
     protected override string Identifier => "Result";
 
     /// <summary>
-    /// Asserts a unit result is a success.
+    /// Asserts a UnitResult is a success.
     /// </summary>
     /// <param name="because"></param>
     /// <param name="becauseArgs"></param>
@@ -31,7 +31,7 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
     }
 
     /// <summary>
-    /// Asserts a unit result is a failure.
+    /// Asserts a UnitResult is a failure.
     /// </summary>
     /// <param name="because"></param>
     /// <param name="becauseArgs"></param>
@@ -47,7 +47,7 @@ public class UnitResultAssertions<E> : ReferenceTypeAssertions<UnitResult<E>, Un
     }
 
     /// <summary>
-    /// Asserts a unit result is a failure with a specified error.
+    /// Asserts a UnitResult is a failure with a specified error.
     /// </summary>
     /// <param name="error"></param>
     /// <param name="because"></param>

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultAssertionTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultAssertionTests.cs
@@ -25,15 +25,17 @@ public class ResultAssertionTests
     }
 
     [Fact]
-    public void WhenResultIsExpectedToHaveErrorItShouldNotBeFailure()
+    public void WhenResultIsExpectedToHaveErrorFailShouldNotThrow()
     {
-        var result = Result.Failure("error");
+        string error = "error";
+        var result = Result.Failure(error);
 
         result.Should().Fail();
+        result.Should().FailWith(error);
     }
 
     [Fact]
-    public void WhenResultIsExpectedToHaveErrorItShouldBeFailure()
+    public void WhenResultIsExpectedToHaveErrorSucceedShouldThrow()
     {
         var result = Result.Failure("error");
 

--- a/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTAssertionsTests.cs
+++ b/tests/CSharpFunctionalExtensions.FluentAssertions.Tests/ResultTAssertionsTests.cs
@@ -44,17 +44,19 @@ public class ResultAssertionsTests
     }
 
     [Fact]
-    public void WhenResultIsExpectedToHaveErrorItShouldNotBeFailure()
+    public void WhenResultIsExpectedToHaveErrorFailShouldNotThrow()
     {
-        var result = Result.Failure<string>("error");
+        string error = "error";
+        var result = Result.Failure<int>(error);
 
         result.Should().Fail();
+        result.Should().FailWith(error);
     }
 
     [Fact]
-    public void WhenResultIsExpectedToHaveErrorItShouldBeFailure()
+    public void WhenResultIsExpectedToHaveErrorSucceedShouldThrow()
     {
-        var result = Result.Failure<string>("error");
+        var result = Result.Failure<int>("error");
 
         var action = () => result.Should().Succeed();
 


### PR DESCRIPTION
Fixes #37

- Add FailWith to `Result` Assertions
- Add FailWith to `Result<T>` Assertions 

- Also updates a few XML comments and test names to be a little clearer (maybe? 🤷‍♂️ 👀  )