### PR TITLE
Change to netstandard2.0 to be compatible with .Net

### DIFF
--- a/src/CSharpFunctionalExtensions.FluentAssertions/CSharpFunctionalExtensions.FluentAssertions.csproj
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/CSharpFunctionalExtensions.FluentAssertions.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<Description>
 			This package provides a set of extensions to FluentAssertions to simplify the testing of project using CSharpFunctionalExtensions


### PR DESCRIPTION
This change allows .Net folks (.Net 4.7.2, .Net 4.8) to use this goodness.

FluentAssertions and CSharpFunctionalExtensions are already compatible.