### PR TITLE
Update CSharpFunctionalExtensions to v3.0.0

### DIFF
--- a/src/CSharpFunctionalExtensions.FluentAssertions/CSharpFunctionalExtensions.FluentAssertions.csproj
+++ b/src/CSharpFunctionalExtensions.FluentAssertions/CSharpFunctionalExtensions.FluentAssertions.csproj
@@ -14,7 +14,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CSharpFunctionalExtensions" Version="2.37.0" />
+		<PackageReference Include="CSharpFunctionalExtensions" Version="3.0.0" />
 		<PackageReference Include="FluentAssertions" Version="6.10.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request includes a version upgrade for the `CSharpFunctionalExtensions` package in the `src/CSharpFunctionalExtensions.FluentAssertions/CSharpFunctionalExtensions.FluentAssertions.csproj` file.

* [`src/CSharpFunctionalExtensions.FluentAssertions/CSharpFunctionalExtensions.FluentAssertions.csproj`](diffhunk://#diff-b8c03912c5258079519cddfb27ed7c29060d7c66ed8b82c905a7c019333528feL17-R17): Upgraded `CSharpFunctionalExtensions` package from version 2.37.0 to 3.0.0.